### PR TITLE
Fixed broken links for AWS and Azure

### DIFF
--- a/docs/home.md
+++ b/docs/home.md
@@ -15,8 +15,8 @@ Contributions are very much welcome. Details on how to contribute can be found h
 
 ## Cloud Providers
 
-- [AWS](aws/index/)
-- [Azure](azure/index/)
+- [AWS](aws/)
+- [Azure](azure/)
 
 ## Cloud/DevOps Tooling
 


### PR DESCRIPTION
Removed "/index" from the links