### PR TITLE
Removing duplicate links

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -23,24 +23,6 @@ module.exports = {
       },
       items: [
         {
-          type: 'doc',
-          docId: 'aws/index',
-          position: 'left',
-          label: 'AWS',
-        },
-        {
-          type: 'doc',
-          docId: 'azure/index',
-          position: 'left',
-          label: 'Azure',
-        },
-        {
-          type: 'doc',
-          docId: 'home',
-          position: 'left',
-          label: 'Saas',
-        },
-        {
           to: '/contributing',
           label: 'Contributing',
           position: 'right'


### PR DESCRIPTION
We have same set of links in header and left sidebar. This can be confusing and I think the links in header are actually useless. Additionally, the link for SaaS is not working.