### PR TITLE
Added languages for syntax highlighting

### DIFF
--- a/docs/azure/services/Azure_Storage_Accounts.md
+++ b/docs/azure/services/Azure_Storage_Accounts.md
@@ -196,7 +196,7 @@ These combinations of service-level permissions, and Storage Account-level ones,
 
 To check the public access setting for all containers in a Storage Account (PowerShell):
 
-```PowerShell
+```powerShell
 $storageAccount = Get-AzStorageAccount -ResourceGroupName <resourcegroup-name> -Name <storageaccount-name>
 $ctx = $storageAccount.Context
 
@@ -220,13 +220,13 @@ Controls that are commonly insecurely configured include:
 
 #### Is encryption at rest enforced?
 PowerShell:
-```Powershell
+```powershell
 (Get-AzResource -ResourceGroupName <resourcegroup-name> -ResourceType Microsoft.Storage/storageAccounts -Name <storageaccount-name>).Properties.encryption | ConvertTo-Json
 ```
 
 #### Are HTTPS-only connections enforced?
 PowerShell:
-```Powershell
+```powershell
 Get-AzStorageAccount -Name <storageaccount-name> -ResourceGroupName <resourcegroup-name> | Select-Object StorageAccountName, EnableHttpsTrafficOnly
 ```
 
@@ -237,7 +237,7 @@ az storage account list --query [*].[name,enableHttpsTrafficOnly] -o table --sub
 
 #### Are insecure TLS versions permitted?
 PowerShell:
-```Powershell
+```powershell
 Get-AzStorageAccount -Name <storageaccount-name> -ResourceGroupName <resourcegroup-name> | Select-Object StorageAccountName, MinimumTlsVersion
 ```
 

--- a/docs/azure/services/Azure_Storage_Accounts.md
+++ b/docs/azure/services/Azure_Storage_Accounts.md
@@ -196,7 +196,7 @@ These combinations of service-level permissions, and Storage Account-level ones,
 
 To check the public access setting for all containers in a Storage Account (PowerShell):
 
-```powerShell
+```powershell
 $storageAccount = Get-AzStorageAccount -ResourceGroupName <resourcegroup-name> -Name <storageaccount-name>
 $ctx = $storageAccount.Context
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -65,7 +65,7 @@ module.exports = {
     prism: {
       theme: lightCodeTheme,
       darkTheme: darkCodeTheme,
-      additionalLanguages: ['powershell','http','hcl', 'bicep'],
+      additionalLanguages: ['powershell','http','hcl','bicep'],
     },
   },
   presets: [

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -65,6 +65,7 @@ module.exports = {
     prism: {
       theme: lightCodeTheme,
       darkTheme: darkCodeTheme,
+      additionalLanguages: ['powershell','http','hcl', 'bicep'],
     },
   },
   presets: [


### PR DESCRIPTION
- Added PowerShell, HTTP, HCL and BICEP syntax highlighting support to Prism. details: https://docusaurus.io/docs/markdown-features/code-blocks#supported-languages)
- Fixed up PowerShell language tag on Azure Storage.