### PR TITLE
Stripping azure from service names

### DIFF
--- a/docs/azure/_category_.json
+++ b/docs/azure/_category_.json
@@ -1,4 +1,4 @@
 {
-  "label": "Azure",
+  "label": "Microsoft Azure",
   "position": 2
 }

--- a/docs/azure/services/key_vault.md
+++ b/docs/azure/services/key_vault.md
@@ -1,4 +1,4 @@
-# Azure Key Vault
+# Key Vault
 
 ## Service Details
 

--- a/docs/azure/services/lighthouse.md
+++ b/docs/azure/services/lighthouse.md
@@ -1,4 +1,4 @@
-# Azure Lighthouse
+# Lighthouse
 
 ## Overview
 

--- a/docs/azure/services/logic_apps.md
+++ b/docs/azure/services/logic_apps.md
@@ -1,4 +1,4 @@
-# Azure Logic Apps
+# Logic Apps
 
 ## General Security Notes:
 

--- a/docs/azure/services/monitor.md
+++ b/docs/azure/services/monitor.md
@@ -1,4 +1,4 @@
-# Azure Monitor
+# Monitor
 
 ## Service Description
 

--- a/docs/azure/services/storage.md
+++ b/docs/azure/services/storage.md
@@ -1,7 +1,7 @@
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-# Azure Storage
+# Storage
 ## Overview
 When looking at storage of data in Azure, we have 3 main categories:
 * Data used directly by VMs such as OS, installed programs, etc. (we would use Azure Disks to store this)

--- a/docs/azure/services/virtual_machines.md
+++ b/docs/azure/services/virtual_machines.md
@@ -1,4 +1,4 @@
-# Azure Virtual Machines
+# Virtual Machines
 
 
 ## Overview

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,5 @@
+## Redirects for Azure services following restructures and filename changes
+
 [[redirects]]
   from = "/azure/services/azure_mfa"
   to = "/azure/services/azure_ad/multi_factor_authentication"

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,3 +5,27 @@
 [[redirects]]
   from = "/azure/services/azure_identity_protection"
   to = "/azure/services/azure_ad/identity_protection"
+
+[[redirects]]
+  from = "/azure/services/azure_key_vault"
+  to = "/azure/services/key_vault"
+
+[[redirects]]
+  from = "/azure/services/azure_logicapps"
+  to = "/azure/services/logic_apps"
+
+[[redirects]]
+  from = "/azure/services/azure_storage"
+  to = "/azure/services/storage"
+
+[[redirects]]
+  from = "/azure/services/azure_lighthouse"
+  to = "/azure/services/lighthouse"
+
+[[redirects]]
+  from = "/azure/services/azure_vm"
+  to = "/azure/services/virtual_machines"
+
+[[redirects]]
+  from = "/azure/services/azure_monitoring"
+  to = "/azure/services/monitor"


### PR DESCRIPTION
Update to strip 'Azure' from service names. Following changes have been made:
- Remove azure from file names and article headers (excluding Azure Active Directory)
- azure service filenames all lowercase (this fixes the sorting as it's case sensitive)
- added in netlify redirects
- update 'Azure' category name to 'Microsoft Azure' (file is the same name so URL has not changed for this)