### PR TITLE
Fixing default branch name in linting

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -10,11 +10,12 @@ name: Lint Code Base
 # Start the job on all push #
 #############################
 on:
+  # Run on pushes to main
   push:
-    branches: [master, main]
-    # Remove the line above to run when pushing to master
+    branches: [main]
+  # Run on PRs to main
   pull_request:
-    branches: [master, main]
+    branches: [main]
 
 ###############
 # Set the Job #
@@ -50,5 +51,5 @@ jobs:
           VALIDATE_ALL_CODEBASE: false
           VALIDATE_MARKDOWN: true
           MARKDOWN_CONFIG_FILE: '.markdownlint.yaml'
-          DEFAULT_BRANCH: master
+          DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
@chrisphilipov this should fix the linting issue. Here's a run [before the change](https://github.com/x-delfino/cloud-wiki/actions/runs/4298502394/jobs/7492676564), and here's [one after](https://github.com/x-delfino/cloud-wiki/actions/runs/4298555985/jobs/7492788640).

default branch was set as master not main in the pipeline